### PR TITLE
CSS fix - when there are no items, the new-todo input is not clickable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea*
 target/
 .cache
 .classpath

--- a/src/main/resources/css/base.css
+++ b/src/main/resources/css/base.css
@@ -139,7 +139,7 @@ input[type="checkbox"] {
 	padding: 16px 16px 16px 60px;
 	border: none;
 	background: rgba(0, 0, 0, 0.02);
-	z-index: 2;
+	z-index: 100;
 	box-shadow: none;
 }
 


### PR DESCRIPTION
The new-todo input is not clickable due to the `#footer:before` element coming in front of it when all todo items have been removed.
