### PR TITLE
Update project.Build.sbt to include spray-json

### DIFF
--- a/project/build.sbt
+++ b/project/build.sbt
@@ -3,4 +3,7 @@ addSbtPlugin("org.scala-lang.modules.scalajs" % "scalajs-sbt-plugin" % "0.5.3")
 
 resolvers += "spray repo" at "http://repo.spray.io"
 
+resolvers  += "Online Play Repository" at
+  "http://repo.typesafe.com/typesafe/simple/maven-releases/"
+
 addSbtPlugin("com.lihaoyi" % "workbench" % "0.1.3")


### PR DESCRIPTION
Seems that TypeSafe moved spray's JSon repository, so this has to be included now.

This was the only change I had to make to get started in SBT and load the example.
