### PR TITLE
Optimisations for the ray-tracer

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,11 +9,11 @@ name := "Example"
 
 version := "0.1-SNAPSHOT"
 
-scalaVersion := "2.11.4"
+scalaVersion := "2.11.6"
 
 libraryDependencies ++= Seq(
   "org.scala-js" %%% "scalajs-dom" % "0.8.0",
-  "org.scala-lang.modules" %% "scala-async" % "0.9.1",
+  "org.scala-lang.modules" %% "scala-async" % "0.9.2",
   "com.nativelibs4java" %% "scalaxy-loops" % "0.1.1" % "provided"
 )
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.7
+sbt.version=0.13.8

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.2")
 
 addSbtPlugin("com.lihaoyi" % "workbench" % "0.2.3")

--- a/src/main/scala/example/ScalaJSExample.scala
+++ b/src/main/scala/example/ScalaJSExample.scala
@@ -305,9 +305,9 @@ class Scene(objects: Array[(Form, Surface)],
     for(y <- 0 until canvas.height optimized){
       if (y % 2 == 0) await(Future())
       canvas.save(y)
+      val ycomp = vpUp * (y * pixelHeight - halfHeight)
       for (x <- 0 until canvas.width optimized){
         val xcomp = vpRight * (x * pixelWidth - halfWidth)
-        val ycomp = vpUp * (y * pixelHeight - halfHeight)
         val ray = Ray(eye.point, xcomp + ycomp + eye.vector)
         val color = rayColor(ray, 0)
         canvas.plot(x, y, color)

--- a/src/main/scala/example/ScalaJSExample.scala
+++ b/src/main/scala/example/ScalaJSExample.scala
@@ -85,14 +85,13 @@ object ScalaJSExample {
     val c = new Canvas{
       val width = canvas.width.toInt
       val height = canvas.height.toInt
-      val data = ctx.getImageData(0, 0, canvas.width, canvas.height)
+      val data = ctx.getImageData(0, 0, canvas.width, 1)
       def save(y: Int): Unit = {
-        println("Saving...")
-        ctx.putImageData(data, 0, 0, 0, y-1, width, 1)
+        ctx.putImageData(data, 0, y-1)
       }
 
       def plot(x: Int, y: Int, rgb: ScalaJSExample.Color): Unit = {
-        val index = (y * data.width.toInt + x) * 4
+        val index = x * 4
         data.data(index+0) = (rgb.x * 255).toInt
         data.data(index+1) = (rgb.y * 255).toInt
         data.data(index+2) = (rgb.z * 255).toInt


### PR DESCRIPTION
* Create only a slice of image data, instead of the full-sized 1024x1024 bitmap
* Bumped the versions of dependencies

----------------
I was also able to switch to scalaxy-streams instead of scalaxy-loops. I can push that in a separate PR.