### PR TITLE
Fixes Framework crash when parentElement is null

### DIFF
--- a/src/main/scala/example/Framework.scala
+++ b/src/main/scala/example/Framework.scala
@@ -37,7 +37,9 @@ object Framework {
     var last = rSafe
     Obs(r, skipInitial = true){
       val newLast = rSafe
-      Option(last.parentElement) map (_.replaceChild(newLast, last))
+      if (last.parentElement != null) {
+        last.parentElement.replaceChild(newLast, last)
+      }
       last = newLast
     }
     last

--- a/src/main/scala/example/Framework.scala
+++ b/src/main/scala/example/Framework.scala
@@ -37,10 +37,10 @@ object Framework {
     var last = rSafe
     Obs(r, skipInitial = true){
       val newLast = rSafe
-      last.parentElement.replaceChild(newLast, last)
+      Option(last.parentElement) map (_.replaceChild(newLast, last))
       last = newLast
     }
-    bindNode(last)
+    last
   }
   implicit def RxAttrValue[T: AttrValue] = new AttrValue[Rx[T]]{
     def apply(t: Element, a: Attr, r: Rx[T]): Unit = {


### PR DESCRIPTION
Also replaces the return value to be the same as in the TodoMVC fiddle since 2015-02-05: https://gist.github.com/lihaoyi/9443f8e0ecc68d1058ad/revisions#diff-c9777f5627a69a4d3d58a8ec92db4a02L55
