### PR TITLE
Fixes possible leak of Rx[T] in Framework

### DIFF
--- a/src/main/scala/example/Framework.scala
+++ b/src/main/scala/example/Framework.scala
@@ -44,12 +44,12 @@ object Framework {
   }
   implicit def RxAttrValue[T: AttrValue] = new AttrValue[Rx[T]]{
     def apply(t: Element, a: Attr, r: Rx[T]): Unit = {
-      Obs(r){ implicitly[AttrValue[T]].apply(t, a, r())}
+      Obs(r){ implicitly[AttrValue[T]].apply(t, a, r.now)}
     }
   }
   implicit def RxStyleValue[T: StyleValue] = new StyleValue[Rx[T]]{
     def apply(t: Element, s: Style, r: Rx[T]): Unit = {
-      Obs(r){ implicitly[StyleValue[T]].apply(t, s, r())}
+      Obs(r){ implicitly[StyleValue[T]].apply(t, s, r.now)}
     }
   }
 


### PR DESCRIPTION
Authored as suggested by @Voltir on 2016-01-02.
Timestamps in UTC-3:

"""
Voltir 13:48
@gabriel-bezerra since you are making pull requests, there is another bug you can fix -- change the instances of r() to r.now or else you end up "leaking" rx dependencies into the passed function, which can cause some really unexpected behavior
This shows up if you use some rx.Var.map, for instance

Voltir 14:12
Obs already observes the rx variable by virtue of the constructor
So you don't need to apply it in the body of the obs

Voltir 14:13
And it leaks in when that thing is implicitly summoned, if there happens to be an rx scope, that outer rx will get a dependency on r
"""

See: https://gitter.im/scala-js/scala-js?at=5687ff6a3acb611716009970
