### PR TITLE
Autowire akka http - updates

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,8 +26,8 @@ val example = crossProject.settings(
 ).jvmSettings(
   name := "Server",
   libraryDependencies ++= Seq(
-    "com.typesafe.akka" %% "akka-http-experimental" % "2.4.11",
-    "com.typesafe.akka" %% "akka-actor" % "2.4.12",
+    "com.typesafe.akka" %% "akka-http" % "10.0.5",
+    "com.typesafe.akka" %% "akka-actor" % "2.4.17",
     "org.webjars" % "bootstrap" % "3.2.0"
   )
 )

--- a/example/js/src/main/scala/example/ScalaJSExample.scala
+++ b/example/js/src/main/scala/example/ScalaJSExample.scala
@@ -1,10 +1,8 @@
 package example
 import scala.scalajs.js.annotation.JSExport
 import org.scalajs.dom
-import org.scalajs.dom.html
-import scala.util.Random
 import scala.concurrent.Future
-import scalajs.concurrent.JSExecutionContext.Implicits.runNow
+import scalajs.concurrent.JSExecutionContext.Implicits.queue
 import scalatags.JsDom.all._
 import upickle.default._
 import upickle.Js

--- a/example/jvm/src/main/scala/example/Server.scala
+++ b/example/jvm/src/main/scala/example/Server.scala
@@ -7,6 +7,7 @@ import akka.http.scaladsl.model._
 import akka.http.scaladsl.server.Directives._
 import akka.stream.ActorMaterializer
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
 
 object Template{
   import scalatags.Text.all._
@@ -53,12 +54,12 @@ object Server extends Api {
       } ~
       post {
         path("api" / Segments){ s =>
-          extract(entity(as[String])) { e =>
+          extractStrictEntity(300.millis) { e =>
             complete {
               AutowireServer.route[Api](Server)(
                 autowire.Core.Request(
                   s,
-                  upickle.json.read(e).asInstanceOf[Js.Obj].value.toMap
+                  upickle.json.read(e.data.utf8String).asInstanceOf[Js.Obj].value.toMap
                 )
               ).map(upickle.json.write(_))
             }


### PR DESCRIPTION
I've tried the autowire-akka-http branch and it didn't compile anymore.

This pull request 

- fixes the akka-http Server compilation error
- fixes a warning in the js module concerning the usage of scalajs.concurrent.JSExecutionContext.Implicits.runNow.
- updates the akka dependencies