### PR TITLE
Update sbt version

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.7
+sbt.version=0.13.17


### PR DESCRIPTION
Some 4 years after the last commit in the repository, it seems that the required rbt version 0.13.7 is nowhere to be found. To oldest sbt version known to https://www.scala-sbt.org is `0.13.15`, while the latest in the 0.13.x series is `0.13.17`. Setting the latter as the required sbt version inside `project/build.properties` fixes project's startup. SBT versions from 1.0.x seem not to work.

I guess this change would need to be merged in the other branches too.